### PR TITLE
feat: expose more `SFCStyleCompileOptions` in style option

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -59,7 +59,17 @@ export interface Options {
       | 'transformAssetUrls'
     >
   >
-  style?: Partial<Pick<SFCStyleCompileOptions, 'trim'>>
+  style?: Partial<
+    Pick<
+      SFCStyleCompileOptions,
+      | 'trim'
+      | 'preprocessLang'
+      | 'preprocessOptions'
+      | 'preprocessCustomRequire'
+      | 'postcssOptions'
+      | 'postcssPlugins'
+    >
+  >
 
   /**
    * Transform Vue SFCs into custom elements.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Expose more SFCStyleCompileOptions in style option. Because sometimes we need pass some parameters like `preprocessLang` into `compileStyleAsync` in `@vue/compiler-sfc`.

### Additional context

See this [code](https://play.vuejs.org/#eNqNUsFOwzAM/ZXIB07QCXYb3SRAO8ABEHCMhLrUtN3SJErcbajqv+O0KtthmiblEL/3Yj/baeHBuWTbIMwgDcpXjkRAatxCGmVNIEG4JzEXEkrU2oqd9TqXcC9NOhn0rOSAsHY6I+RIiDSvtkLpLIS5BJd5NCShZ05y36qsYtLFbTph9gLh3aXCth0a6LrDi/GWTo5McxjoV6MIyjrMGUmGVKKNb1aZ2hTeNia/UVZbPxMrzRCPIbJXQ71Bekq8KytCFgvRScOHZxeLcRW4BuKS5qcqknWwhvfQZ5GgbO0qjf7NUcWbkDAb80vIeBW7lx4j3+D1iKsS1eYEvg77iEl49xjQb1HCP0eZL5D3E+nl5ytP64isbd5oVp8hPzBY3USPg+yR+2bbR7re7XPtrKfKFF9huSc0YWwqGu0n0+sl8Gd8OtP6we40mY4The4PREbvfA==) in vue official playground. It produce a css output:

```scss
.parent[data-v-7ba5bd90] {
  background-color: black;
&_child[data-v-7ba5bd90] {
    background-color: white;
}
}
```

But sass can't process this output, so we need pass `preprocessLang` into `compileStyleAsync` to call it internal preprocessor. But there isn't option `preprocessLang` in `Options.style`. So it need to be expanded.
