### PR TITLE
chore: remove postcssPlugins & preprocessLang in style's omitted

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -96,9 +96,7 @@ export interface Options {
       | 'cssDevSourcemap'
       | 'postcssOptions'
       | 'map'
-      | 'postcssPlugins'
       | 'preprocessCustomRequire'
-      | 'preprocessLang'
       | 'preprocessOptions'
     >
   >


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

#### Why remove those?

- `postcssPlugins`: more time I want to using `unocss` + `tsup`, my `tsup.config.ts` will be this:
```ts
import { defineConfig } from 'tsup'
import { undts } from 'undts/esbuild'
import unocss from 'unocss/postcss'
import vue from 'unplugin-vue/esbuild'

export default defineConfig({
  entry: {
    index: './src/index.ts',
  },
  format: ['cjs', 'esm'],
  dts: false,
  clean: true,
  sourcemap: true,
  esbuildPlugins: [
    undts(),

    vue({
      style: {
        // eslint-disable-next-line ts/ban-ts-comment
        // @ts-expect-error
        preprocessLang: 'less',
        postcssPlugins: [unocss()],
      },
    }),
  ],
})
```
I don't understand why use type to exclude this option, it's actually very useful.
- `preprocessLang`: When I want to using preprocessLang + vue + tsup, I seeing this repo's [examples/esbuild example](https://github.com/unplugin/unplugin-vue/blob/main/examples/esbuild/build.js#L20), why type exclude it and then ask the compiler to ignore it? Feel very strange for me.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
